### PR TITLE
feat(debugging): Generate source maps for generated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Override project configuration with `ATSCM_PROJECT` env variables ([8798d4e](https://github.com/atSCM/atscm/commit/8798d4e))
 * **ci:** Automated release ([#65](https://github.com/atSCM/atscm/issues/65)) ([dcf48b7](https://github.com/atSCM/atscm/commit/dcf48b7))
+* **debugging:** Generate source-map ([84e23dc](https://github.com/atSCM/atscm/commit/84e23dc))
 
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "atscm-cli": ">=0.2.0"
   },
   "scripts": {
-    "compile": "babel src --out-dir out",
+    "compile": "babel src --out-dir out --source-maps",
     "compile:watch": "npm run compile -- --watch",
     "commitmsg": "conventional-changelog-lint -e",
     "docs": "esdoc -c esdoc.json",


### PR DESCRIPTION
Adds "source-maps" switch in compile task call to generate source-maps with babel.
This makes it possible to avoid debugging of transpiled files in Webstorm node environment and maybe other environments as well