### PR TITLE
fix(AtviseFile): Add encoding for byte strings

### DIFF
--- a/src/lib/server/AtviseFile.js
+++ b/src/lib/server/AtviseFile.js
@@ -103,6 +103,7 @@ const Decoder = {
 const Encoder = {
   [DataType.DateTime]: date => date.getTime().toString(),
   [DataType.UInt64]: uInt32Array => JSON.stringify(uInt32Array),
+  [DataType.ByteString]: binaryArray => new Buffer(binaryArray, 'binary'),
 };
 
 /**


### PR DESCRIPTION
Adds encoding for byte strings to the encoder object so binary atvise nodes are pulled correctly.

Fixes #62