### PR TITLE
refactor: Use own module for project defaults

### DIFF
--- a/src/init/Options.js
+++ b/src/init/Options.js
@@ -1,6 +1,6 @@
 import { basename } from 'path';
 import InitOption from '../lib/init/Option';
-import Atviseproject from '../lib/config/Atviseproject';
+import defaults from '../lib/config/defaults';
 import Validator from './OptionsValidator';
 
 /**
@@ -36,9 +36,9 @@ export const InitOptions = {
   }),
   description: new InitOption('Project description'),
   author: new InitOption('Project author'),
-  atviseHost: new InitOption('Atvise server host', Atviseproject.host),
-  atvisePortOpc: new InitOption('Atvise OPC port', Atviseproject.port.opc),
-  atvisePortHttp: new InitOption('Atvise HTTP port', Atviseproject.port.http),
+  atviseHost: new InitOption('Atvise server host', defaults.host),
+  atvisePortOpc: new InitOption('Atvise OPC port', defaults.port.opc),
+  atvisePortHttp: new InitOption('Atvise HTTP port', defaults.port.http),
   useLogin: new InitOption({
     message: 'Does your atvise server require login',
     type: 'confirm',

--- a/src/lib/config/Atviseproject.js
+++ b/src/lib/config/Atviseproject.js
@@ -3,6 +3,7 @@
 import NodeId from '../ua/NodeId';
 import DisplayTransformer from '../../transform/DisplayTransformer';
 import ScriptTransformer from '../../transform/ScriptTransformer';
+import defaults from './defaults';
 
 /**
  * An *atvise-scm* project's configuration.
@@ -15,7 +16,7 @@ export default class Atviseproject {
    * @type {String}
    */
   static get host() {
-    return 'localhost';
+    return defaults.host;
   }
 
   /**
@@ -26,8 +27,8 @@ export default class Atviseproject {
    */
   static get port() {
     return {
-      opc: 4840,
-      http: 80,
+      opc: defaults.port.opc,
+      http: defaults.port.http,
     };
   }
 

--- a/src/lib/config/defaults.js
+++ b/src/lib/config/defaults.js
@@ -1,0 +1,7 @@
+export default {
+  host: 'localhost',
+  port: {
+    opc: 4840,
+    http: 80,
+  },
+};


### PR DESCRIPTION
Fixes an issue where `atscm init` didn't work