### PR TITLE
fix(test): Remove transformers from configuration

### DIFF
--- a/src/lib/config/Atviseproject.js
+++ b/src/lib/config/Atviseproject.js
@@ -1,9 +1,5 @@
 /* eslint-disable no-useless-escape */
-
 import NodeId from '../ua/NodeId';
-import DisplayTransformer from '../../transform/DisplayTransformer';
-import ScriptTransformer from '../../transform/ScriptTransformer';
-import defaults from './defaults';
 
 /**
  * An *atvise-scm* project's configuration.
@@ -80,17 +76,6 @@ export default class Atviseproject {
   }
 
   /**
-   * The transformers to use in this project. Defaults to a single {@link DisplayTransformer}
-   * @type {Transformer[]}
-   */
-  static get useTransformers() {
-    return [
-      new DisplayTransformer(),
-      new ScriptTransformer(),
-    ];
-  }
-
-  /**
    * The atvise-server nodes that atvise-scm should sync. Defaults to
    * `['ns=1;s=AGENT', 'ns=1;s=SYSTEM', 'ns=1;s=ObjectTypes.PROJECT']`
    * @type {String[]|NodeId[]}
@@ -151,7 +136,6 @@ export default class Atviseproject {
       login: this.login,
       useTransformers: this.useTransformers,
       nodes: this.nodes,
-      nodesToWatch: this.nodesToWatch,
       ignoreNodes: this.ignoreNodes,
     };
   }

--- a/src/transform/FileToAtviseFileTransformer.js
+++ b/src/transform/FileToAtviseFileTransformer.js
@@ -1,8 +1,9 @@
 import { src } from 'gulp';
 import CombinedStream from 'combined-stream';
-import ProjectConfig from '../config/ProjectConfig';
 import Transformer, { TransformDirection } from '../lib/transform/Transformer';
 import MappingTransformer from './Mapping';
+import ScriptTransformer from './DisplayTransformer';
+import DisplayTransformer from './ScriptTransformer';
 
 /**
  * A transformer that transforms mapped file system files to {@link AtviseFiles}'s
@@ -20,8 +21,8 @@ export default class FileToAtviseFileTransformer {
    */
   constructor(options = {}) {
     /**
-     * Combined stream instance.
-     * @type {CombinedStream}
+     * The resulting stream.
+     * @type {Stream}
      */
     const combinedSrcStream = CombinedStream.create();
 
@@ -41,6 +42,14 @@ export default class FileToAtviseFileTransformer {
 
     nodesToTransform.map(nodeId => combinedSrcStream
       .append(src(`./src/${nodeId.filePath}/**/*.*`)));
+    /**
+     * The streams to apply.
+     * @type {Transformer[]}
+     */
+    const applyTransformers = [
+      new DisplayTransformer(),
+      new ScriptTransformer()
+    ];
 
     if (options.applyTransformers !== undefined && options.applyTransformers === false) {
       return combinedSrcStream
@@ -49,9 +58,9 @@ export default class FileToAtviseFileTransformer {
 
     return Transformer.applyTransformers(
       combinedSrcStream
-        .pipe(mappingStream),
-      ProjectConfig.useTransformers,
-      TransformDirection.FromFilesystem
-    );
-  }
+          .pipe(mappingStream),
+        applyTransformers,
+        TransformDirection.FromFilesystem
+      );
+    }
 }


### PR DESCRIPTION
Removes transformers from Atviseproject default
configuration to avoid circular import of node modules.
This lead to import erros especially in unit tests.