### PR TITLE
fix: Fix invalid Boolean decoding

### DIFF
--- a/src/lib/server/AtviseFile.js
+++ b/src/lib/server/AtviseFile.js
@@ -212,7 +212,7 @@ export default class AtviseFile extends File {
       return buffer;
     }
 
-    const stringValue = buffer.toString();
+    const stringValue = buffer.toString().trim();
 
     const decoder = Decoder[dataType];
     const decode = s => {


### PR DESCRIPTION
Fixes an issue whre booleans are decoded to the wrong value when the file has trailing newlines