### PR TITLE
fix(pull): Warn if datasource is not connected

### DIFF
--- a/src/lib/server/ReadStream.js
+++ b/src/lib/server/ReadStream.js
@@ -31,13 +31,13 @@ export default class ReadStream extends QueueStream {
       this.session.read([{ nodeId }], (err, nodesToRead, results) => {
         if (!err && (!results || results.length === 0)) {
           handleErrors(new Error('No results'));
-        } else if (results && results.length && results[0].statusCode === StatusCodes.BadServerNotConnected) {
+        } else if (results[0].statusCode === StatusCodes.BadServerNotConnected) {
           handleErrors(err, StatusCodes.Good, done => {
-            Logger.warn(`${nodeId} could not be read because it\'s datasource is not connected`);
+            Logger.warn(`${nodeId.value} could not be read because it's datasource is not connected`);
             done();
           });
         } else {
-          handleErrors(err, results && results.length > 0 ? results[0].statusCode : null, done => {
+          handleErrors(err, results[0].statusCode, done => {
             this.push({
               nodeClass,
               nodeId,

--- a/src/lib/server/ReadStream.js
+++ b/src/lib/server/ReadStream.js
@@ -33,7 +33,9 @@ export default class ReadStream extends QueueStream {
           handleErrors(new Error('No results'));
         } else if (results[0].statusCode === StatusCodes.BadServerNotConnected) {
           handleErrors(err, StatusCodes.Good, done => {
-            Logger.warn(`${nodeId.value} could not be read because it's datasource is not connected`);
+            Logger.warn(`${
+              nodeId.value
+            } could not be read because it's datasource is not connected`);
             done();
           });
         } else {

--- a/src/lib/server/ReadStream.js
+++ b/src/lib/server/ReadStream.js
@@ -29,7 +29,10 @@ export default class ReadStream extends QueueStream {
   processChunk({ nodeClass, nodeId, references }, handleErrors) {
     if (nodeClass.value === NodeClass.Variable.value) {
       this.session.read([{ nodeId }], (err, nodesToRead, results) => {
-        if (!err && (!results || results.length === 0)) {
+        if (err) {
+          const status = results && results.length && results[0].statusCode;
+          handleErrors(err, status, done => done());
+        } else if (!results || results.length === 0) {
           handleErrors(new Error('No results'));
         } else if (results[0].statusCode === StatusCodes.BadServerNotConnected) {
           handleErrors(err, StatusCodes.Good, done => {

--- a/src/lib/server/ReadStream.js
+++ b/src/lib/server/ReadStream.js
@@ -31,7 +31,7 @@ export default class ReadStream extends QueueStream {
       this.session.read([{ nodeId }], (err, nodesToRead, results) => {
         if (err) {
           const status = results && results.length && results[0].statusCode;
-          handleErrors(err, status, done => done());
+          handleErrors(err, status);
         } else if (!results || results.length === 0) {
           handleErrors(new Error('No results'));
         } else if (results[0].statusCode === StatusCodes.BadServerNotConnected) {


### PR DESCRIPTION
If a mirrored node's datasource is not connected we cannot read it (obviously). Trying to do so causes an error which now gets handled. A warning is printed.

Fixes #3 