### PR TITLE
fix: Preserve xml element order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -265,8 +265,7 @@
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-      "dev": true
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
     },
     "accepts": {
       "version": "1.3.3",
@@ -650,10 +649,26 @@
         "buffer-equal": "1.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "optional": true
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "optional": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.2.11"
+      }
     },
     "argparse": {
       "version": "0.1.16",
@@ -2402,6 +2417,14 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
     "bluebird": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
@@ -2782,6 +2805,12 @@
       "resolved": "https://registry.npmjs.org/buffer-replace/-/buffer-replace-1.0.0.tgz",
       "integrity": "sha1-vEJ8QK9MHwbWkz3t5XEQrLqK3lQ=",
       "dev": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "optional": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -3335,6 +3364,11 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
       "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -3828,8 +3862,7 @@
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3916,6 +3949,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true
     },
     "depd": {
       "version": "1.1.0",
@@ -5201,14 +5240,12 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5758,829 +5795,28 @@
       "requires": {
         "nan": "2.6.2",
         "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "optional": true
-        },
-        "aproba": {
-          "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-          "optional": true,
-          "requires": {
-            "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
-          }
-        },
-        "asn1": {
-          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "optional": true
-        },
-        "asynckit": {
-          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "optional": true
-        },
-        "aws4": {
-          "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-        },
-        "bcrypt-pbkdf": {
-          "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "optional": true,
-          "requires": {
-            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-          }
-        },
-        "block-stream": {
-          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-          }
-        },
-        "boom": {
-          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
-        },
-        "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-          "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-          }
-        },
-        "buffer-shims": {
-          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-        },
-        "caseless": {
-          "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "optional": true
-        },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-          }
-        },
-        "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "requires": {
-            "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-          }
-        },
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "optional": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          }
-        },
-        "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "console-control-strings": {
-          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "cryptiles": {
-          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-          }
-        },
-        "dashdash": {
-          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "optional": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-          }
-        },
-        "deep-extend": {
-          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "delegates": {
-          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "optional": true
-        },
-        "extend": {
-          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-        },
-        "forever-agent": {
-          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "optional": true
-        },
-        "form-data": {
-          "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-          "optional": true,
-          "requires": {
-            "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
-          }
-        },
-        "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "fstream": {
-          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-          }
-        },
-        "fstream-ignore": {
-          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "optional": true,
-          "requires": {
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-          }
-        },
-        "gauge": {
-          "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-          "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
-          "optional": true,
-          "requires": {
-            "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-          }
-        },
-        "generate-function": {
-          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "optional": true,
-          "requires": {
-            "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-          }
-        },
-        "getpass": {
-          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-          }
-        },
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "graceful-readlink": {
-          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "optional": true
-        },
-        "har-validator": {
-          "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "optional": true,
-          "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-          }
-        },
-        "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-          }
-        },
-        "has-unicode": {
-          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "optional": true
-        },
-        "hawk": {
-          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "optional": true,
-          "requires": {
-            "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-          }
-        },
-        "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-            "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz"
-          }
-        },
-        "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        },
-        "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "ini": {
-          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-          }
-        },
-        "is-my-json-valid": {
-          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-          "optional": true,
-          "requires": {
-            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          }
-        },
-        "is-property": {
-          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "optional": true
-        },
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isstream": {
-          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "optional": true,
-          "requires": {
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-          }
-        },
-        "jsbn": {
-          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-        },
-        "json-schema": {
-          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-          "optional": true
-        },
-        "jsprim": {
-          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-          "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-            "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-          }
-        },
-        "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-          "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
-        },
-        "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-          "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
-          "requires": {
-            "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
-          }
-        },
-        "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-          }
-        },
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          }
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
-          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
-          "optional": true,
-          "requires": {
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-            "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-            "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz"
-          }
-        },
-        "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "optional": true,
-          "requires": {
-            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-          }
-        },
-        "npmlog": {
-          "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-            "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-          }
-        },
-        "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "oauth-sign": {
-          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "optional": true
-        },
-        "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "optional": true
-        },
-        "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        },
-        "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "pinkie": {
-          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "optional": true
-        },
-        "pinkie-promise": {
-          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "optional": true,
-          "requires": {
-            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-          }
-        },
-        "process-nextick-args": {
-          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "punycode": {
-          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "optional": true
-        },
-        "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
-          "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
-          "optional": true
-        },
-        "rc": {
-          "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-          "optional": true,
-          "requires": {
-            "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-          "optional": true,
-          "requires": {
-            "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-          }
-        },
-        "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "optional": true,
-          "requires": {
-            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "qs": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
-            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-          }
-        },
-        "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-          "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-          }
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "optional": true
-        },
-        "sntp": {
-          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "optional": true,
-          "requires": {
-            "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-          }
-        },
-        "sshpk": {
-          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
-          "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
-          "optional": true,
-          "requires": {
-            "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-            "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-            "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "stringstream": {
-          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-          }
-        },
-        "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "optional": true
-        },
-        "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "optional": true
-        },
-        "tar": {
-          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "requires": {
-            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-          }
-        },
-        "tar-pack": {
-          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-          "optional": true,
-          "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-            "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-            "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-          },
-          "dependencies": {
-            "once": {
-              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-              "optional": true,
-              "requires": {
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              }
-            },
-            "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-              "optional": true,
-              "requires": {
-                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-              }
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "optional": true,
-          "requires": {
-            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-          }
-        },
-        "tunnel-agent": {
-          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        },
-        "uid-number": {
-          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "optional": true
-        },
-        "verror": {
-          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "optional": true,
-          "requires": {
-            "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-          }
-        },
-        "wide-align": {
-          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-          "optional": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-          }
-        },
-        "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "optional": true
-        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "optional": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
       }
     },
     "function-bind": {
@@ -6594,6 +5830,22 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -7881,6 +7133,12 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -8911,8 +8169,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -10059,7 +9316,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -10067,8 +9323,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -10664,6 +9919,251 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+      "integrity": "sha512-42vnYyn2joGJA0lZmoiSEYnRuRhVdB/6+mIdcN6Ue9pIM8NBvTr2x603tSFen39dThxHFNN+BFHZ8G8+LA/V3A==",
+      "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "rc": "1.1.7",
+        "request": "2.83.0",
+        "rimraf": "2.5.4",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "optional": true
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "optional": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "optional": true
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "optional": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "optional": true,
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "optional": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "optional": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "optional": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.1"
+          }
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "optional": true
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "optional": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "optional": true
+        }
+      }
+    },
     "node-uuid": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
@@ -10680,7 +10180,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
       "requires": {
         "abbrev": "1.1.0"
       }
@@ -10792,6 +10291,18 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "nth-check": {
@@ -13074,7 +12585,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
       "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-      "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.4",
@@ -13472,7 +12982,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -13574,7 +13083,8 @@
     "sax": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
-      "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
+      "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg=",
+      "dev": true
     },
     "self-closing-tags": {
       "version": "1.0.1",
@@ -13756,8 +13266,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "4.2.2",
@@ -14354,8 +13863,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "success-symbol": {
       "version": "0.1.0",
@@ -14494,6 +14002,73 @@
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.2.tgz",
       "integrity": "sha1-e/gQalwaSCUbPjvAoOFzJIn9Dcg=",
       "dev": true
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tar-pack": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+      "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+      "optional": true,
+      "requires": {
+        "debug": "2.2.0",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.3.3",
+        "readable-stream": "2.1.5",
+        "rimraf": "2.5.4",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "optional": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "optional": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
+        }
+      }
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -14967,6 +14542,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "optional": true
     },
     "ultron": {
@@ -15542,6 +15123,15 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "optional": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "win-release": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
@@ -15624,6 +15214,21 @@
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
+    "xml-js": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.2.tgz",
+      "integrity": "sha512-7SyYB9qfahPf+0eu0W2dZbFzcjk9dDiKRMbQGwSsaTCCiUG0NOawi3CjSJRPOGsS6C6poOoMfYaLc4HZJWjlLw==",
+      "requires": {
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        }
+      }
+    },
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
@@ -15640,6 +15245,7 @@
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dev": true,
       "requires": {
         "sax": "1.2.2",
         "xmlbuilder": "4.2.1"
@@ -15649,6 +15255,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       },
@@ -15656,7 +15263,8 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "through2": "^2.0.3",
     "validate-npm-package-name": "^3.0.0",
     "vinyl": "^2.0.1",
-    "xml2js": "^0.4.17"
+    "xml-js": "^1.6.2"
   },
   "eslintConfig": {
     "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:coverage": "esdoc-coverage -c esdoc.json",
     "lint": "eslint src test",
     "prepublishOnly": "npm run compile && npm run docs",
-    "test": "cross-env NODE_ENV=test mocha --recursive --require babel-register \"test/src/**/*.spec.js\" --require ./test/prepare --timeout 10000 --exit",
+    "test": "cross-env NODE_ENV=test mocha --recursive --require babel-register \"test/**/*.spec.js\" --require ./test/prepare --timeout 10000 --exit",
     "test:watch": "npm test -- --watch --reporter min",
     "test:coverage": "nyc --reporter=html npm test",
     "test:docs": "blcl docs/api --exclude https://circleci.com/gh/atSCM/atscm"

--- a/test/issues/issue-46.spec.js
+++ b/test/issues/issue-46.spec.js
@@ -1,0 +1,26 @@
+import expect from '../expect';
+import { TransformDirection } from '../../src/lib/transform/Transformer';
+import XMLTransformer from '../../src/lib/transform/XMLTransformer';
+
+describe('XMLTransformer', function() {
+  it('should keep element order', async function() {
+    const testContents = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" width="1280" height="680">
+  <text>text1</text>
+  <rect width="200" height="200" x="160" y="16"/>
+  <text>text2</text>
+</svg>`;
+    const testFile = { contents: Buffer.from(testContents) };
+    const transformer = new XMLTransformer({
+      direction: TransformDirection.FromDB, // just to have os-native newlines
+    });
+
+    const [decoded] = await expect(cb => transformer.decodeContents(testFile, cb),
+      'to call the callback without error');
+
+    const [encoded] = await expect(cb => transformer.encodeContents(decoded, cb),
+      'to call the callback without error');
+
+    expect(encoded, 'to equal', testContents);
+  });
+});

--- a/test/src/lib/transform/XMLTransformer.spec.js
+++ b/test/src/lib/transform/XMLTransformer.spec.js
@@ -1,5 +1,6 @@
 import expect from 'unexpected';
-import { Builder } from 'xml2js';
+// import { Builder } from 'xml2js';
+import { xml2js } from 'xml-js';
 import Transformer, { TransformDirection } from '../../../../src/lib/transform/Transformer';
 import XMLTransformer from '../../../../src/lib/transform/XMLTransformer';
 
@@ -15,14 +16,14 @@ describe('XMLTransformer', function() {
       const transformer = new XMLTransformer();
 
       expect(transformer._fromDBBuilder, 'to be defined');
-      expect(transformer._fromDBBuilder, 'to be a', Builder);
+      expect(transformer._fromDBBuilder, 'to be a', 'function');
     });
 
     it('should create a _fromFilesystemBuilder', function() {
       const transformer = new XMLTransformer();
 
       expect(transformer._fromDBBuilder, 'to be defined');
-      expect(transformer._fromDBBuilder, 'to be a', Builder);
+      expect(transformer._fromDBBuilder, 'to be a', 'function');
     });
   });
 
@@ -47,7 +48,7 @@ describe('XMLTransformer', function() {
   describe('#decodeContents', function() {
     it('should forward errors', function(done) {
       expect(cb => (new XMLTransformer()).decodeContents({ contents: 'no valid xml' }, cb),
-        'to call the callback with error', /Non-whitespace before first tag./)
+        'to call the callback with error', /Text data outside of root node./)
         .then(() => done());
     });
 
@@ -56,11 +57,26 @@ describe('XMLTransformer', function() {
         'to call the callback')
         .then(args => {
           expect(args[0], 'to be falsy');
-          expect(args[1], 'to equal', { tag: 'value' });
+          expect(args[1], 'to equal', { elements: [{
+            type: 'element',
+            name: 'tag',
+            elements: [{
+              type: 'text',
+              text: 'value',
+            }],
+          }] });
           done();
         });
     });
   });
+
+  const baseXmlObject = xml2js(`<root>
+  <sub>test</sub>
+</root>`, { compact: false });
+
+  const cdataXmlObject = xml2js(`<svg>
+  <script><![CDATA[test();]]></script>
+</svg>`);
 
   function testBuilder(direction, object, expectedResult, callback) {
     const transformer = new XMLTransformer({ direction });
@@ -77,12 +93,12 @@ describe('XMLTransformer', function() {
   describe('#encodeContents', function() {
     it('should forward errors', function() {
       expect(cb => (new XMLTransformer()).encodeContents(null, cb),
-        'to call the callback with error', 'Cannot convert undefined or null to object');
+        'to call the callback with error', /Cannot read property/);
     });
 
     context('when direction is FromDB', function() {
       it('should indent with double space', function(done) {
-        testBuilder(TransformDirection.FromDB, { root: { sub: 'test' } },
+        testBuilder(TransformDirection.FromDB, baseXmlObject,
           `<root>
   <sub>test</sub>
 </root>`, done);
@@ -91,26 +107,20 @@ describe('XMLTransformer', function() {
 
     context('when direction is FromFilesytem', function() {
       it('should indent with single space', function(done) {
-        testBuilder(TransformDirection.FromFilesystem, { root: { sub: 'test' } },
+        testBuilder(TransformDirection.FromFilesystem, baseXmlObject,
           '<root>\r\n <sub>test</sub>\r\n</root>', done);
       });
     });
 
-    it('should support forced CDATA', function() {
+    it('should support CDATA', function() {
       return expect(cb => (new XMLTransformer({ direction: TransformDirection.FromDB }))
-        .encodeContents({
-          svg: {
-            script: [
-              { _: XMLTransformer.forceCData('test()') },
-            ],
-          },
-        }, cb), 'to call the callback')
+        .encodeContents(cdataXmlObject, cb), 'to call the callback')
         .then(args => expect(args[1], 'to end with', `<svg>
-  <script><![CDATA[test()]]></script>
+  <script><![CDATA[test();]]></script>
 </svg>`));
     });
 
-    it('should not double escape forced CDATA', function() {
+    /* it('should not double escape forced CDATA', function() {
       return expect(cb => (new XMLTransformer({ direction: TransformDirection.FromFilesystem }))
         .encodeContents({
           svg: {
@@ -121,6 +131,202 @@ describe('XMLTransformer', function() {
         }, cb), 'to call the callback')
         .then(args => expect(args[1], 'to contain',
           '<script><![CDATA[console.log("<asdf>")]]></script>'));
+    }); */
+  });
+
+  describe('DOM helpers', function() {
+    /** @test {XMLTransformer#isElement} */
+    describe('#isElement', function() {
+      it('should return true for element nodes', function() {
+        return expect(XMLTransformer.prototype.isElement, 'when called with', [{ type: 'element' }],
+          'to equal', true);
+      });
+
+      it('should return false for text nodes', function() {
+        return expect(XMLTransformer.prototype.isElement, 'when called with', [{ type: 'text' }],
+          'to equal', false);
+      });
+    });
+
+    /** @test {XMLTransformer#isElementWithName} */
+    describe('#isElementWithName', function() {
+      it('should return false for non-element nodes', function() {
+        return expect(XMLTransformer.prototype.isElementWithName.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'text' }, 'elementname'],
+          'to equal', false);
+      });
+
+      it('should return false for non-matching elements', function() {
+        return expect(XMLTransformer.prototype.isElementWithName.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'element', name: 'another' }, 'elementname'],
+          'to equal', false);
+      });
+
+      it('should return true for matching elements', function() {
+        return expect(XMLTransformer.prototype.isElementWithName.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'element', name: 'elementname' }, 'elementname'],
+          'to equal', true);
+      });
+    });
+
+    /** @test {XMLTransformer#findChildren} */
+    describe('#findChildren', function() {
+      it('should return empty array for non-elements', function() {
+        return expect(XMLTransformer.prototype.findChildren.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'text' }, 'elementname'],
+          'to equal', []);
+      });
+
+      it('should empty array for text content nodes', function() {
+        return expect(XMLTransformer.prototype.findChildren.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'text', text: 'just text' },
+            ],
+          }, 'elementname'],
+          'to equal', []);
+      });
+
+      it('should filter child elements', function() {
+        const matching = {
+          type: 'element',
+          name: 'elementname',
+        };
+        return expect(XMLTransformer.prototype.findChildren.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'element', name: 'another' },
+              matching,
+            ],
+          }, 'elementname'],
+          'to equal', [matching]);
+      });
+    });
+
+    /** @test {XMLTransformer#findChild} */
+    describe('#findChild', function() {
+      it('should return null for non-elements', function() {
+        return expect(XMLTransformer.prototype.findChild.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'text' }, 'elementname'],
+          'to equal', null);
+      });
+
+      it('should null for text content nodes', function() {
+        return expect(XMLTransformer.prototype.findChild.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'text', text: 'just text' },
+            ],
+          }, 'elementname'],
+          'to equal', null);
+      });
+
+      it('should return first matching child elements', function() {
+        const matching = {
+          type: 'element',
+          name: 'elementname',
+        };
+        return expect(XMLTransformer.prototype.findChild.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'element', name: 'another' },
+              matching,
+              { type: 'element', name: 'elementname', elements: [] },
+            ],
+          }, 'elementname'],
+          'to equal', matching);
+      });
+    });
+
+    /** @test {XMLTransformer#findChildren} */
+    describe('#removeChildren', function() {
+      it('should return empty array for non-elements', function() {
+        return expect(XMLTransformer.prototype.removeChildren.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'text' }, 'elementname'],
+          'to equal', []);
+      });
+
+      it('should empty array for text content nodes', function() {
+        return expect(XMLTransformer.prototype.removeChildren.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'text', text: 'just text' },
+            ],
+          }, 'elementname'],
+          'to equal', []);
+      });
+
+      it('should filter child elements', async function() {
+        const matching = {
+          type: 'element',
+          name: 'elementname',
+        };
+
+        const node = {
+          type: 'element',
+          elements: [
+            { type: 'element', name: 'another' },
+            matching,
+          ],
+        };
+
+        await expect(XMLTransformer.prototype.removeChildren.bind(XMLTransformer.prototype),
+          'when called with', [node, 'elementname'],
+          'to equal', [matching]);
+
+        // Should remove match from elements array
+        expect(node.elements.length, 'to equal', 1);
+        expect(node.elements.includes(matching), 'to be', false);
+      });
+    });
+
+    /** @test {XMLTransformer#removeChild} */
+    describe('#removeChild', function() {
+      it('should return null for non-elements', function() {
+        return expect(XMLTransformer.prototype.removeChild.bind(XMLTransformer.prototype),
+          'when called with', [{ type: 'text' }, 'elementname'],
+          'to equal', null);
+      });
+
+      it('should null for text content nodes', function() {
+        return expect(XMLTransformer.prototype.removeChild.bind(XMLTransformer.prototype),
+          'when called with', [{
+            type: 'element',
+            elements: [
+              { type: 'text', text: 'just text' },
+            ],
+          }, 'elementname'],
+          'to equal', null);
+      });
+
+      it('should return first matching child elements', async function() {
+        const matching = {
+          type: 'element',
+          name: 'elementname',
+        };
+
+        const node = {
+          type: 'element',
+          elements: [
+            { type: 'element', name: 'another' },
+            matching,
+            { type: 'element', name: 'elementname', elements: [] },
+          ],
+        };
+
+        await expect(XMLTransformer.prototype.removeChild.bind(XMLTransformer.prototype),
+          'when called with', [node, 'elementname'],
+          'to equal', matching);
+
+        // Should remove match from elements array
+        expect(node.elements.length, 'to equal', 2);
+        expect(node.elements.includes(matching), 'to be', false);
+      });
     });
   });
 });

--- a/test/src/transform/DisplayTransformer.spec.js
+++ b/test/src/transform/DisplayTransformer.spec.js
@@ -149,10 +149,21 @@ ${xmlString}`),
       });
     });
 
-    context('when display contains metadata', function() {
-      it('should work without parameters', function() {
+    context('when display contains metadata tag', function() {
+      it('should work without actual metadata', function() {
         return expectConfig(`<svg>
   <metadata></metadata>
+</svg>`)
+          .then(config => {
+            expect(config, 'to be defined');
+          });
+      });
+
+      it('should work without parameters', function() {
+        return expectConfig(`<svg>
+  <metadata>
+    <atv:gridconfig height="20" width="20" enabled="false" gridstyle="lines"/>
+  </metadata>
 </svg>`)
           .then(config => {
             expect(config, 'to be defined');
@@ -237,7 +248,7 @@ ${xmlString}`),
     it('should fail with invalid SVG', function() {
       return expect(createDisplayWithFileContents({
         '.svg': 'invalid XML',
-      }), 'to call the callback with error', /Non-whitespace before first tag/);
+      }), 'to call the callback with error', /Text data outside of root node/);
     });
 
     it('should fail without `svg` tag', function() {
@@ -304,8 +315,8 @@ ${xmlString}`.replace(/\r?\n|\r/g, '\r\n'));
         '.json': '{ "parameters": [{ "name": "test" }] }',
       }, `<svg>
  <metadata>
-  <atv:gridconfig height="20" width="20" enabled="false" gridstyle="lines"/>
   <atv:parameter name="test"/>
+  <atv:gridconfig height="20" width="20" enabled="false" gridstyle="lines"/>
  </metadata>
 </svg>`);
     });
@@ -331,8 +342,38 @@ ${xmlString}`.replace(/\r?\n|\r/g, '\r\n'));
         '.json': '{ "parameters": [{ "name": "test" }] }',
       }, `<svg>
  <metadata>
-  <atv:parameter name="existant"/>
   <atv:parameter name="test"/>
+  <atv:parameter name="existant"/>
+ </metadata>
+</svg>`);
+    });
+
+    it('should insert parameters before other atv tags', function() {
+      return expectDisplayWithFileContentToHaveXML({
+        '.svg': `<svg>
+  <metadata>
+    <atv:parameter name="existant"/>
+    <atv:gridconfig height="20" width="20" enabled="false" gridstyle="lines"/>
+  </metadata>
+</svg>`,
+        '.json': '{ "parameters": [{ "name": "test" }] }',
+      }, `<svg>
+ <metadata>
+  <atv:parameter name="test"/>
+  <atv:parameter name="existant"/>
+  <atv:gridconfig height="20" width="20" enabled="false" gridstyle="lines"/>
+ </metadata>
+</svg>`);
+    });
+
+    it('should insert parameters in the correct order', function() {
+      return expectDisplayWithFileContentToHaveXML({
+        '.svg': '<svg></svg>',
+        '.json': '{ "parameters": [{ "name": "test" }, { "name": "another" }] }',
+      }, `<svg>
+ <metadata>
+  <atv:parameter name="test"/>
+  <atv:parameter name="another"/>
  </metadata>
 </svg>`);
     });

--- a/test/src/transform/ScriptTransformer.spec.js
+++ b/test/src/transform/ScriptTransformer.spec.js
@@ -61,6 +61,31 @@ describe('ScriptTransformer', function() {
         });
     });
 
+    it('should only store metadata elements', function() {
+      return transformerHelper.writeXMLToTransformer(ScriptPath, `<script>
+  <metadata>shouldn't be handled</metadata>
+</script>`)
+        .then(files => transformerHelper.expectFileContents(files))
+        .then(contents => expect(JSON.parse(contents[0]), 'to equal', {}));
+    });
+
+    it('should warn on unknown metadata elements', function() {
+      const onWarn = spy();
+      Logger.on('warn', onWarn);
+
+      return transformerHelper.writeXMLToTransformer(ScriptPath, `<script>
+  <metadata>
+    <custom>test</custom>
+  </metadata>
+</script>`)
+        .then(files => transformerHelper.expectFileContents(files))
+        .then(contents => expect(JSON.parse(contents[0]), 'to equal', {}))
+        .then(() => {
+          expect(onWarn, 'was called once');
+          expect(onWarn, 'to have a call satisfying', { args: [/unknown metadata/i] });
+        });
+    });
+
     it('should store icon metadata', function() {
       return transformerHelper.writeXMLToTransformer(ScriptPath, `<script>
   <metadata>
@@ -99,6 +124,18 @@ describe('ScriptTransformer', function() {
         .then(files => transformerHelper.expectFileContents(files))
         .then(contents => expect(JSON.parse(contents[0]), 'to equal', {
           visible: true,
+        }));
+    });
+
+    it('should properly interpret visible metadata', function() {
+      return transformerHelper.writeXMLToTransformer(ScriptPath, `<script>
+  <metadata>
+    <visible>0</visible>
+  </metadata>
+</script>`)
+        .then(files => transformerHelper.expectFileContents(files))
+        .then(contents => expect(JSON.parse(contents[0]), 'to equal', {
+          visible: false,
         }));
     });
 


### PR DESCRIPTION
Changing the xml parser and builder library to preserve the xml element order.
XmlTransformer, ScriptTransfromer and DisplayTransformer were updated.

Fixes #46