### PR TITLE
feat: Continue on failure with `--continue` flag used

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "out/index.js",
   "engines": {
     "node": ">=8.0",
-    "atscm-cli": ">=0.2.0"
+    "atscm-cli": ">=0.5.0"
   },
   "scripts": {
     "compile": "babel src --out-dir out --source-maps",

--- a/src/lib/server/QueueStream.js
+++ b/src/lib/server/QueueStream.js
@@ -2,6 +2,7 @@
 /* eslint-disable jsdoc/check-param-names */
 
 import { StatusCodes } from 'node-opcua';
+import Logger from 'gulplog';
 import Stream from './Stream';
 
 /**
@@ -174,10 +175,21 @@ export default class QueueStream extends Stream {
       };
 
       if (err) {
-        this.emit('error', new Error(`${this.processErrorMessage(chunk)}: ${err.message}`));
+        const message = `${this.processErrorMessage(chunk)}: ${err.message}`;
+
+        if (process.env.CONTINUE_ON_FAILURE) {
+          Logger.error(`FAILURE: ${message}`);
+        } else {
+          this.emit('error', new Error(message));
+        }
       } else if (statusCode !== StatusCodes.Good) {
-        this.emit('error',
-          new Error(`${this.processErrorMessage(chunk)}: ${statusCode.description}`));
+        const message = `${this.processErrorMessage(chunk)}: ${statusCode.description}`;
+
+        if (process.env.CONTINUE_ON_FAILURE) {
+          Logger.error(`FAILURE: ${message}`);
+        } else {
+          this.emit('error', new Error(message));
+        }
       } else {
         onSuccess(finished);
         return;

--- a/src/lib/transform/Transformer.js
+++ b/src/lib/transform/Transformer.js
@@ -1,5 +1,6 @@
 import { inspect } from 'util';
 import { ctor as throughStreamClass } from 'through2';
+import Logger from 'gulplog';
 
 /**
  * The directions a transformer can be run in.
@@ -81,7 +82,12 @@ export default class Transformer extends throughStreamClass({ objectMode: true }
       // eslint-disable-next-line no-param-reassign
       err.message = `[${this.constructor.name}] ${err.message} (in ${id})`;
 
-      callback(err);
+      if (process.env.CONTINUE_ON_FAILURE) {
+        Logger.error(err.message);
+        callback(null);
+      } else {
+        callback(err);
+      }
     } else {
       callback(err, ...args);
     }


### PR DESCRIPTION
From now on the `--continue` flag can be used to pull or push projects that are not fully set up, e.g. they have disconnected datasources or corrupted variable nodes.