### PR TITLE
fix(watcher): Wait for subscriptions and handle deletions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: circleci tests glob "test/src/**/*.spec.js" | circleci tests split --split-by=timings
       - run:
           name: Running tests
-          command: npx nyc -r json --report-dir "coverage/unit-$CIRCLE_NODE_INDEX" --no-check-coverage npm run test:base -- --reporter mocha-circleci-reporter test/src/maintenance.spec.js $(circleci tests glob "test/src/**/*.spec.js" | circleci tests split --split-by=timings)
+          command: npx nyc -r json --report-dir "coverage/unit-$CIRCLE_NODE_INDEX" --no-check-coverage npm run test:base -- --reporter mocha-circleci-reporter $(circleci tests glob "test/src/**/*.spec.js" | circleci tests split --split-by=timings)
           environment:
             NODE_ENV: test
             MOCHA_FILE: ../reports/unit-tests-$CIRCLE_NODE_INDEX.xml

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint src test",
     "prepublishOnly": "npm run compile && npm run docs",
     "test": "npm run -s test:base -- \"test/**/*.spec.js\"",
-    "test:base": "cross-env NODE_ENV=test mocha --recursive --require babel-register --require ./test/prepare --timeout 10000 --exit",
+    "test:base": "cross-env NODE_ENV=test mocha --recursive --require babel-register --require ./test/prepare --timeout 10000 --exit test/src/maintenance.spec.js",
     "test:unit": "npm run -s test:base -- \"test/src/**/*.spec.js\"",
     "test:integration": "npm run -s test:base -- \"test/integration/**/*.spec.js\"",
     "test:watch": "npm test -- --watch --reporter min",

--- a/src/lib/server/Watcher.js
+++ b/src/lib/server/Watcher.js
@@ -189,7 +189,10 @@ export default class Watcher extends Emitter {
 
     this._nodeStream.pipe(this._subscribeStream);
 
-    this._subscribeStream.on('finish', () => this.emit('ready'));
+    // "pipe" subscribe stream
+    this._subscribeStream.on('data', () => {});
+    this._subscribeStream.on('end', () => this.emit('ready'));
+
     this._subscribeStream.on('change', event => this.emit('change', event));
     this._subscribeStream.on('delete', event => this.emit('delete', event));
   }

--- a/src/lib/server/Watcher.js
+++ b/src/lib/server/Watcher.js
@@ -98,7 +98,7 @@ export class SubscribeStream extends QueueStream {
       if (!this._trackChanges) {
         handleErrors(null, StatusCodes.Good, done => done()); // Ignore first notification
       } else {
-        this.emit('change', {
+        this.emit(dataValue.value ? 'change' : 'delete', {
           nodeClass: referenceDescription.nodeClass,
           nodeId,
           value: dataValue.value,
@@ -191,6 +191,7 @@ export default class Watcher extends Emitter {
 
     this._subscribeStream.on('finish', () => this.emit('ready'));
     this._subscribeStream.on('change', event => this.emit('change', event));
+    this._subscribeStream.on('delete', event => this.emit('delete', event));
   }
 
   /**

--- a/src/tasks/watch.js
+++ b/src/tasks/watch.js
@@ -108,14 +108,16 @@ export class WatchTask {
 
   /**
    * Initializes {@link WatchTask#browserSyncInstance}.
+   * @param {Object} options The options to pass to browsersync.
+   * @see https://browsersync.io/docs/options
    */
-  initBrowserSync() {
-    this.browserSyncInstance.init({
+  initBrowserSync(options) {
+    this.browserSyncInstance.init(Object.assign({
       proxy: `${ProjectConfig.host}:${ProjectConfig.port.http}`,
       ws: true,
       // logLevel: 'debug', FIXME: Use log level specified in cli options
       // logPrefix: '',
-    });
+    }, options));
 
     /* bs.logger.logOne = function(args, msg, level, unprefixed) {
       args = args.slice(2);
@@ -205,10 +207,12 @@ export class WatchTask {
   /**
    * Starts the file and server watchers, initializes Browsersync and registers change event
    * handlers.
+   * @param {Object} [options] The options to pass to browsersync.
+   * @param {boolean} [options.open=true] If the browser should be opened once browsersync is up.
    * @return {Promise<undefined, Error>} Fulfilled once all watchers are set up and Browsersync was
    * initialized.
    */
-  run() {
+  run({ open = true } = { open: true }) {
     return Promise.all([
       this.startFileWatcher(),
       this.startServerWatcher(),
@@ -222,7 +226,7 @@ export class WatchTask {
         fileWatcher.on('change', this.handleFileChange.bind(this));
         serverWatcher.on('change', this.handleServerChange.bind(this));
 
-        this.initBrowserSync();
+        this.initBrowserSync({ open });
       });
   }
 
@@ -230,11 +234,13 @@ export class WatchTask {
 
 /**
  * The gulp task invoced when running `atscm watch`.
+ * @param {Object} options The options to pass to the watch task, see {@link WatchTask#run} for
+ * available options.
  * @return {Promise<undefined, Error>} Fulfilled once all watchers are set up and Browsersync was
  * initialized.
  */
-export default function watch() {
-  return (new WatchTask()).run();
+export default function watch(options) {
+  return (new WatchTask()).run(options);
 }
 
 watch.description = 'Watch local files and atvise server nodes to trigger pull/push on change';

--- a/src/tasks/watch.js
+++ b/src/tasks/watch.js
@@ -209,8 +209,8 @@ export class WatchTask {
    * handlers.
    * @param {Object} [options] The options to pass to browsersync.
    * @param {boolean} [options.open=true] If the browser should be opened once browsersync is up.
-   * @return {Promise<undefined, Error>} Fulfilled once all watchers are set up and Browsersync was
-   * initialized.
+   * @return {Promise<{ serverWatcher: Watcher, fileWatcher: sane~Watcher }, Error>} Fulfilled once
+   * all watchers are set up and Browsersync was initialized.
    */
   run({ open = true } = { open: true }) {
     return Promise.all([
@@ -227,6 +227,8 @@ export class WatchTask {
         serverWatcher.on('change', this.handleServerChange.bind(this));
 
         this.initBrowserSync({ open });
+
+        return { fileWatcher, serverWatcher };
       });
   }
 
@@ -236,8 +238,8 @@ export class WatchTask {
  * The gulp task invoced when running `atscm watch`.
  * @param {Object} options The options to pass to the watch task, see {@link WatchTask#run} for
  * available options.
- * @return {Promise<undefined, Error>} Fulfilled once all watchers are set up and Browsersync was
- * initialized.
+ * @return {Promise<{ serverWatcher: Watcher, fileWatcher: sane~Watcher }, Error>} Fulfilled once
+ * all watchers are set up and Browsersync was initialized.
  */
 export default function watch(options) {
   return (new WatchTask()).run(options);

--- a/test/fixtures/Atviseproject.babel.js
+++ b/test/fixtures/Atviseproject.babel.js
@@ -1,4 +1,5 @@
 import Atviseproject from '../../src/lib/config/Atviseproject';
+import NodeId from '../../src/lib/model/opcua/NodeId';
 
 export default class TestProject extends Atviseproject {
 
@@ -18,6 +19,12 @@ export default class TestProject extends Atviseproject {
       username: process.env.ATVISE_USERNAME,
       password: process.env.ATVISE_PASSWORD,
     };
+  }
+
+  static get nodesToWatch() {
+    return [
+      new NodeId('AGENT.DISPLAYS.atSCM.watch'),
+    ];
   }
 
 }

--- a/test/fixtures/setup/issue-157.xml
+++ b/test/fixtures/setup/issue-157.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- created at 2018-03-29 09:47:55 -->
+<!-- created at 2018-04-03 17:14:20 -->
 <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
 	<NamespaceUris>
 		<Uri>http://www.atvise.com/atServer/UA/</Uri>
@@ -50,7 +50,7 @@
 			<Reference ReferenceType="HasTypeDefinition">ns=1;s=ObjectTypes.ATVISE.Server.Local</Reference>
 		</References>
 		<Extensions>
-			<atvise ExportedNodeId="ns=1;s=AGENT.DISPLAYS.DeleteDisplay" ExportedBrowseName="1:DeleteDisplay" Upstream="true"/>
+			<atvise ExportedNodeId="ns=1;s=AGENT.DISPLAYS.atSCM.watch.DeleteDisplay" ExportedBrowseName="1:DeleteDisplay" Upstream="true"/>
 		</Extensions>
 	</UAObject>
 	<UAObject NodeId="ns=1;s=AGENT.DISPLAYS" BrowseName="1:DISPLAYS">
@@ -64,22 +64,44 @@
 			<atvise Upstream="true"/>
 		</Extensions>
 	</UAObject>
-	<UAVariable NodeId="ns=1;s=AGENT.DISPLAYS.DeleteDisplay" BrowseName="1:DeleteDisplay" DataType="XmlElement" AccessLevel="7" UserAccessLevel="7" Historizing="true">
+	<UAObject NodeId="ns=1;s=AGENT.DISPLAYS.atSCM" BrowseName="1:atSCM">
+		<DisplayName Locale="en">atSCM</DisplayName>
+		<Description Locale="en">atSCM</Description>
+		<References>
+			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT.DISPLAYS</Reference>
+			<Reference ReferenceType="HasTypeDefinition">FolderType</Reference>
+		</References>
+		<Extensions>
+			<atvise Upstream="true"/>
+		</Extensions>
+	</UAObject>
+	<UAObject NodeId="ns=1;s=AGENT.DISPLAYS.atSCM.watch" BrowseName="1:watch">
+		<DisplayName Locale="en">watch</DisplayName>
+		<Description Locale="en">watch</Description>
+		<References>
+			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT.DISPLAYS.atSCM</Reference>
+			<Reference ReferenceType="HasTypeDefinition">FolderType</Reference>
+		</References>
+		<Extensions>
+			<atvise Upstream="true"/>
+		</Extensions>
+	</UAObject>
+	<UAVariable NodeId="ns=1;s=AGENT.DISPLAYS.atSCM.watch.DeleteDisplay" BrowseName="1:DeleteDisplay" DataType="XmlElement" AccessLevel="7" UserAccessLevel="7" Historizing="true">
 		<DisplayName Locale="en">DeleteDisplay</DisplayName>
 		<Description Locale="en">DeleteDisplay</Description>
 		<References>
-			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT.DISPLAYS</Reference>
+			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT.DISPLAYS.atSCM.watch</Reference>
 			<Reference ReferenceType="HasTypeDefinition">ns=1;s=VariableTypes.ATVISE.Display</Reference>
 		</References>
 		<Value>
 			<uax:XmlElement><![CDATA[<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg width="1280" version="1.2" xmlns="http://www.w3.org/2000/svg" height="680" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:atv="http://webmi.atvise.com/2007/svgext">
+<svg version="1.2" xmlns:atv="http://webmi.atvise.com/2007/svgext" width="1280" height="680" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs/>
  <metadata>
   <atv:gridconfig width="20" enabled="false" height="20" gridstyle="lines"/>
   <atv:snapconfig width="10" enabled="false" height="10"/>
  </metadata>
- <text x="640" y="344.5" fill="#000000" font-family="Arial" text-anchor="middle" id="id_0" atv:refpx="640" atv:refpy="340" font-size="12">This display will be deleted when running integration tests</text>
+ <text id="id_0" font-size="12" fill="#000000" atv:refpy="340" atv:refpx="640" font-family="Arial" x="640" y="344.5" text-anchor="middle">This display will be deleted when running integration tests</text>
 </svg>
 ]]></uax:XmlElement>
 		</Value>

--- a/test/fixtures/setup/issue-157.xml
+++ b/test/fixtures/setup/issue-157.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- created at 2018-03-29 09:47:55 -->
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+	<NamespaceUris>
+		<Uri>http://www.atvise.com/atServer/UA/</Uri>
+	</NamespaceUris>
+	<Aliases>
+		<!-- data types -->
+		<Alias Alias="Boolean">i=1</Alias>
+		<Alias Alias="SByte">i=2</Alias>
+		<Alias Alias="Byte">i=3</Alias>
+		<Alias Alias="Int16">i=4</Alias>
+		<Alias Alias="UInt16">i=5</Alias>
+		<Alias Alias="Int32">i=6</Alias>
+		<Alias Alias="UInt32">i=7</Alias>
+		<Alias Alias="Int64">i=8</Alias>
+		<Alias Alias="UInt64">i=9</Alias>
+		<Alias Alias="Float">i=10</Alias>
+		<Alias Alias="Double">i=11</Alias>
+		<Alias Alias="String">i=12</Alias>
+		<Alias Alias="DateTime">i=13</Alias>
+		<Alias Alias="ByteString">i=15</Alias>
+		<Alias Alias="XmlElement">i=16</Alias>
+		<Alias Alias="NodeId">i=17</Alias>
+		<Alias Alias="LocalizedText">i=21</Alias>
+		<!-- references -->
+		<Alias Alias="Organizes">i=35</Alias>
+		<Alias Alias="HasEventSource">i=36</Alias>
+		<Alias Alias="HasModellingRule">i=37</Alias>
+		<Alias Alias="HasTypeDefinition">i=40</Alias>
+		<Alias Alias="HasSubtype">i=45</Alias>
+		<Alias Alias="HasProperty">i=46</Alias>
+		<Alias Alias="HasComponent">i=47</Alias>
+		<Alias Alias="HasNotifier">i=48</Alias>
+		<!-- types -->
+		<Alias Alias="BaseDataType">i=24</Alias>
+		<Alias Alias="BaseObjectType">i=58</Alias>
+		<Alias Alias="FolderType">i=61</Alias>
+		<Alias Alias="BaseVariableType">i=62</Alias>
+		<Alias Alias="PropertyType">i=68</Alias>
+		<!-- modelling rules -->
+		<Alias Alias="New">i=78</Alias>
+		<Alias Alias="Shared">i=79</Alias>
+	</Aliases>
+	<UAObject NodeId="ns=1;s=AGENT" BrowseName="1:AGENT">
+		<DisplayName Locale="en">AGENT</DisplayName>
+		<Description Locale="en">AGENT</Description>
+		<References>
+			<Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
+			<Reference ReferenceType="HasTypeDefinition">ns=1;s=ObjectTypes.ATVISE.Server.Local</Reference>
+		</References>
+		<Extensions>
+			<atvise ExportedNodeId="ns=1;s=AGENT.DISPLAYS.DeleteDisplay" ExportedBrowseName="1:DeleteDisplay" Upstream="true"/>
+		</Extensions>
+	</UAObject>
+	<UAObject NodeId="ns=1;s=AGENT.DISPLAYS" BrowseName="1:DISPLAYS">
+		<DisplayName Locale="en">DISPLAYS</DisplayName>
+		<Description Locale="en">DISPLAYS</Description>
+		<References>
+			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT</Reference>
+			<Reference ReferenceType="HasTypeDefinition">FolderType</Reference>
+		</References>
+		<Extensions>
+			<atvise Upstream="true"/>
+		</Extensions>
+	</UAObject>
+	<UAVariable NodeId="ns=1;s=AGENT.DISPLAYS.DeleteDisplay" BrowseName="1:DeleteDisplay" DataType="XmlElement" AccessLevel="7" UserAccessLevel="7" Historizing="true">
+		<DisplayName Locale="en">DeleteDisplay</DisplayName>
+		<Description Locale="en">DeleteDisplay</Description>
+		<References>
+			<Reference ReferenceType="HasComponent" IsForward="false">ns=1;s=AGENT.DISPLAYS</Reference>
+			<Reference ReferenceType="HasTypeDefinition">ns=1;s=VariableTypes.ATVISE.Display</Reference>
+		</References>
+		<Value>
+			<uax:XmlElement><![CDATA[<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg width="1280" version="1.2" xmlns="http://www.w3.org/2000/svg" height="680" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:atv="http://webmi.atvise.com/2007/svgext">
+ <defs/>
+ <metadata>
+  <atv:gridconfig width="20" enabled="false" height="20" gridstyle="lines"/>
+  <atv:snapconfig width="10" enabled="false" height="10"/>
+ </metadata>
+ <text x="640" y="344.5" fill="#000000" font-family="Arial" text-anchor="middle" id="id_0" atv:refpx="640" atv:refpy="340" font-size="12">This display will be deleted when running integration tests</text>
+</svg>
+]]></uax:XmlElement>
+		</Value>
+	</UAVariable>
+</UANodeSet>

--- a/test/helpers/atscm.js
+++ b/test/helpers/atscm.js
@@ -66,8 +66,6 @@ export function callScript(name, parameters) {
     nodeId: new NodeId('ns=1;s=AGENT.TEST.Helper'),
   });
 
-  stream.on('error', console.error.bind(console, '>> error'))
-
   stream.end();
 
   return promisify(stream);

--- a/test/helpers/atscm.js
+++ b/test/helpers/atscm.js
@@ -1,0 +1,74 @@
+import { join } from 'path';
+import replace from 'buffer-replace';
+import promisify from 'stream-to-promise';
+import { obj as createTransformStream } from 'through2';
+import { StatusCodes } from 'node-opcua';
+import { src } from 'gulp';
+import ImportStream from '../../src/lib/gulp/ImportStream';
+import CallScriptStream from '../../src/lib/server/scripts/CallScriptStream';
+import NodeId from '../../src/lib/model/opcua/NodeId';
+
+export function importSetup(name, rename = 'TestNode') {
+  const setupPath = join(__dirname, `../fixtures/setup/${name}.xml`);
+
+  const nodeName = `${rename}-${Date.now().toString(32)}`;
+  const replaceStream = createTransformStream((file, enc, callback) => {
+    callback(null, Object.assign(file, {
+      contents: replace(file.contents, rename, nodeName),
+    }));
+  });
+
+  const importStream = new ImportStream();
+
+  return promisify(
+    src(setupPath)
+      .pipe(replaceStream)
+      .pipe(importStream)
+  )
+    .then(() => nodeName);
+}
+
+class SingleCallScriptStream extends CallScriptStream {
+
+  constructor(options) {
+    super(options);
+
+    this._scriptId = options.script;
+    this._parameters = options.parameters || {};
+  }
+
+  get scriptId() {
+    return this._scriptId;
+  }
+
+  scriptParameters() {
+    return this._parameters;
+  }
+
+  handleOutputArguments(file, outArgs, callback) {
+    if (outArgs[0].value !== StatusCodes.Good) {
+      callback(new Error(outArgs[1].value));
+    } else {
+      callback(null, outArgs.slice(2).map(a => a.value));
+    }
+  }
+
+}
+
+export function callScript(name, parameters) {
+  const stream = new SingleCallScriptStream({
+    script: new NodeId(`ns=1;s=SYSTEM.LIBRARY.ATVISE.SERVERSCRIPTS.atscm.${name}`),
+    parameters,
+  });
+
+  stream.write({
+    relative: 'TestHelper',
+    nodeId: new NodeId('ns=1;s=AGENT.TEST.Helper'),
+  });
+
+  stream.on('error', console.error.bind(console, '>> error'))
+
+  stream.end();
+
+  return promisify(stream);
+}

--- a/test/integration/issues/issue-157.spec.js
+++ b/test/integration/issues/issue-157.spec.js
@@ -23,6 +23,8 @@ describe('watch task', function() {
         });
       });
 
+      await new Promise(resolve => setTimeout(resolve, 100));
+
       // Delete the node
       await callScript('DeleteNode', {
         nodeId: {

--- a/test/integration/issues/issue-157.spec.js
+++ b/test/integration/issues/issue-157.spec.js
@@ -4,12 +4,19 @@ import { importSetup, callScript } from '../../helpers/atscm';
 
 describe('watch task', function() {
   context('when a watched node is deleted', function() {
-    it('should not error', async function() {
+    it('should not error', async function(cb) {
       const nodeName = await importSetup('issue-157', 'DeleteDisplay');
       const nodeId = `AGENT.DISPLAYS.${nodeName}`;
 
       // Start watch task
-      await watch({ open: false });
+      const { serverWatcher } = await watch({ open: false });
+
+      // Wait until deletion is recognized
+      serverWatcher.on('change', r => {
+        if (r.nodeId.value.split(nodeId).length > 1) {
+          cb();
+        }
+      });
 
       // Delete the node
       await callScript('DeleteNode', {

--- a/test/integration/issues/issue-157.spec.js
+++ b/test/integration/issues/issue-157.spec.js
@@ -23,8 +23,6 @@ describe('watch task', function() {
         });
       });
 
-      await new Promise(resolve => setTimeout(resolve, 100));
-
       // Delete the node
       await callScript('DeleteNode', {
         nodeId: {

--- a/test/integration/issues/issue-157.spec.js
+++ b/test/integration/issues/issue-157.spec.js
@@ -1,0 +1,23 @@
+import { DataType } from 'node-opcua';
+import watch from '../../../src/tasks/watch';
+import { importSetup, callScript } from '../../helpers/atscm';
+
+describe('watch task', function() {
+  context('when a watched node is deleted', function() {
+    it('should not error', async function() {
+      const nodeName = await importSetup('issue-157', 'DeleteDisplay');
+      const nodeId = `AGENT.DISPLAYS.${nodeName}`;
+
+      // Start watch task
+      await watch({ open: false });
+
+      // Delete the node
+      await callScript('DeleteNode', {
+        nodeId: {
+          dataType: DataType.String,
+          value: nodeId,
+        },
+      });
+    });
+  });
+});

--- a/test/integration/issues/issue-157.spec.js
+++ b/test/integration/issues/issue-157.spec.js
@@ -6,7 +6,7 @@ describe('watch task', function() {
   context('when a watched node is deleted', function() {
     it('should not error', async function() {
       const nodeName = await importSetup('issue-157', 'DeleteDisplay');
-      const nodeId = `AGENT.DISPLAYS.${nodeName}`;
+      const nodeId = `AGENT.DISPLAYS.atSCM.watch.${nodeName}`;
 
       // Start watch task
       const { serverWatcher } = await watch({ open: false });

--- a/test/src/lib/server/Watcher.spec.js
+++ b/test/src/lib/server/Watcher.spec.js
@@ -199,6 +199,43 @@ describe('SubscribeStream', function() {
           }]);
         });
     });
+
+    it('should emit delete events without a value', function() {
+      const stream = new SubscribeStream();
+      const nodeId = resolveNodeId('ns=1;s=AGENT.DISPLAYS.Main');
+      const listener = spy();
+      stream.on('delete', listener);
+
+      const event = {
+        serverTimestamp: new Date(),
+      };
+
+      let item;
+
+      stream.once('subscription-started', subscription => {
+        stub(subscription, 'monitor').callsFake(() => {
+          item = new StubMonitoredItem(false);
+          return item;
+        });
+      });
+
+      return expect(
+        [{
+          nodeId,
+          nodeClass: NodeClass.Variable,
+          references: {},
+        }],
+        'when piped through', stream,
+        'to yield objects satisfying', 'to have length', 0)
+        .then(() => item.emit('changed', event))
+        .then(() => {
+          expect(listener, 'was called once');
+          expect(listener.lastCall, 'to satisfy', [{
+            nodeId,
+            references: {},
+          }]);
+        });
+    });
   });
 
   /** @test {SubscribeStream#_transform} */


### PR DESCRIPTION
- Fixes an issue where the atvise server watcher emitted the 'ready' event before all subscriptions were set up (May be the reason for #91) 
- Fixes an issue where the 'watch' task crashed when a watched node was deleted inside atvise builder 

Fixes #157