### PR TITLE
fix: Do not transform reference config files

### DIFF
--- a/src/lib/server/AtviseFile.js
+++ b/src/lib/server/AtviseFile.js
@@ -116,6 +116,8 @@ function extensionForDataType(dataType) {
   return ExtensionForDataType[dataType] || dataType.toString().toLowerCase();
 }
 
+const ConfigFileRegexp = /^\.((Object|Variable)(Type)?|Method|View|(Reference|Data)Type)\.json$/;
+
 /**
  * An extension to {@link vinyl~File} providing some additional, atvise-related properties.
  * @property {node-opcua~DataType} AtviseFile#dataType The {@link node-opcua~DataType} the node is
@@ -458,6 +460,15 @@ export default class AtviseFile extends File {
     }
 
     return new NodeId(NodeId.NodeIdType.NUMERIC, 0, 0);
+  }
+
+  // eslint-disable-next-line jsdoc/require-description-complete-sentence
+  /**
+   * `true` for reference config files (for example `.index.htm.json`).
+   * @type {boolean}
+   */
+  get isReferenceConfig() {
+    return this.stem[0] === '.' && !this.stem.match(ConfigFileRegexp);
   }
 
   /**

--- a/src/lib/transform/Transformer.js
+++ b/src/lib/transform/Transformer.js
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 import { ctor as throughStreamClass } from 'through2';
 import Logger from 'gulplog';
+import AtviseFile from '../server/AtviseFile';
 
 /**
  * The directions a transformer can be run in.
@@ -58,6 +59,16 @@ export default class Transformer extends throughStreamClass({ objectMode: true }
     }
   }
 
+  // eslint-disable-next-line jsdoc/require-description-complete-sentence
+  /**
+   * If reference config files should be handled by the transformer. Override if you want to
+   * transform reference config files (for example `.index.htm.json`).
+   * @type {boolean}
+   */
+  get transformsReferenceConfigFiles() {
+    return false;
+  }
+
   /**
    * Returns the Transformer with the given direction.
    * @param {TransformDirection} direction The direction to use.
@@ -110,6 +121,10 @@ export default class Transformer extends throughStreamClass({ objectMode: true }
    * @throws {Error} Throws an error if the transformer has no valid direction.
    */
   _transform(chunk, enc, callback) {
+    if (!this.transformsReferenceConfigFiles && chunk instanceof AtviseFile && chunk.isReferenceConfig) {
+      callback(null, chunk);
+      return;
+    }
     const processError = (err, ...args) => this._processError(err, chunk, callback, ...args);
 
     if (!this.direction) {

--- a/src/lib/transform/Transformer.js
+++ b/src/lib/transform/Transformer.js
@@ -121,7 +121,8 @@ export default class Transformer extends throughStreamClass({ objectMode: true }
    * @throws {Error} Throws an error if the transformer has no valid direction.
    */
   _transform(chunk, enc, callback) {
-    if (!this.transformsReferenceConfigFiles && chunk instanceof AtviseFile && chunk.isReferenceConfig) {
+    if (!this.transformsReferenceConfigFiles && chunk instanceof AtviseFile &&
+      chunk.isReferenceConfig) {
       callback(null, chunk);
       return;
     }

--- a/src/transform/Mapping.js
+++ b/src/transform/Mapping.js
@@ -127,4 +127,11 @@ export default class MappingTransformer extends Transformer {
     }
   }
 
+  /**
+   * `true` as the mapping transformer should infer references from config files.
+   */
+  get transformsReferenceConfigFiles() {
+    return true;
+  }
+
 }

--- a/test/src/lib/transform/Transformer.spec.js
+++ b/test/src/lib/transform/Transformer.spec.js
@@ -4,6 +4,7 @@ import { stub } from 'sinon';
 import { obj as createStream } from 'through2';
 import expect from '../../../expect';
 import Transformer, { TransformDirection } from '../../../../src/lib/transform/Transformer';
+import AtviseFile from '../../../../src/lib/server/AtviseFile';
 
 /** @test {Transformer} */
 describe('Transformer', function() {
@@ -67,6 +68,19 @@ describe('Transformer', function() {
       transformer.withDirection(TransformDirection.FromFilesystem)._transform({}, 'utf8', () => {});
 
       return expect(transformer.transformFromFilesystem, 'was called');
+    });
+
+    it('should skip reference config files', function() {
+      const file = new AtviseFile({ path: './some/path/.index.htm.json' });
+      const stream = transformer.withDirection(TransformDirection.FromFilesystem);
+      return expect([file], 'when piped through', stream,
+        'to yield chunks satisfying', [
+          expect.it('to be', file),
+        ])
+        .then(() => {
+          expect(transformer.transformFromDB, 'was not called');
+          expect(transformer.transformFromFilesystem, 'was not called');
+        });
     });
   });
 


### PR DESCRIPTION
Fixes an issue introduced in v0.6.0-beta.25, where the script transformer attempts to transform the reference config files of script nodes.