### PR TITLE
fix: Cast typed arrays to regular array objects

### DIFF
--- a/src/lib/server/AtviseFile.js
+++ b/src/lib/server/AtviseFile.js
@@ -269,7 +269,9 @@ const toNodeValue = {
  */
 const getRawValue = (value, dataType, arrayType) => {
   if (arrayType.value !== VariantArrayType.Scalar.value) {
-    return value.map(val => getRawValue(val, dataType, VariantArrayType[arrayType.value - 1]));
+    const array = Array.isArray(value) ? value : Array.from(value);
+
+    return array.map(val => getRawValue(val, dataType, VariantArrayType[arrayType.value - 1]));
   }
 
   return (toRawValue[dataType] || asIs)(value);
@@ -283,6 +285,10 @@ const getRawValue = (value, dataType, arrayType) => {
  */
 const getNodeValue = (rawValue, dataType, arrayType) => {
   if (arrayType.value !== VariantArrayType.Scalar.value) {
+    if (!Array.isArray(rawValue)) {
+      throw new Error('Value is not an array');
+    }
+
     return rawValue.map(raw => getNodeValue(raw, dataType, VariantArrayType[arrayType.value - 1]));
   }
 

--- a/src/lib/server/AtviseFile.js
+++ b/src/lib/server/AtviseFile.js
@@ -256,7 +256,6 @@ const toNodeValue = {
     mapPropertyAs(toNodeValue, opts, 'innerStatusCode', DataType.StatusCode);
     mapPropertyAs(toNodeValue, opts, 'innerDiagnosticInfo', DataType.DiagnosticInfo);
 
-
     return new DiagnosticInfo(opts);
   },
 };

--- a/test/fixtures/dataTypes.js
+++ b/test/fixtures/dataTypes.js
@@ -61,7 +61,7 @@ export const samples = [
     dataType: DataType.DateTime,
   },
   {
-    value: '01234567-89ab-cdef-0123-456789ab',
+    value: '01234567-89ab-cdef-0123-456789abcdef',
     dataType: DataType.Guid,
   },
   {
@@ -85,7 +85,7 @@ export const samples = [
     dataType: DataType.StatusCode,
   },
   {
-    value: new QualifiedName({ namespaceIndex: 0, name: 'Test' }),
+    value: new QualifiedName({ namespaceIndex: 3, name: 'Test' }),
     dataType: DataType.QualifiedName,
   },
   {

--- a/test/src/lib/server/AtviseFile.spec.js
+++ b/test/src/lib/server/AtviseFile.spec.js
@@ -180,6 +180,13 @@ describe('AtviseFile', function() {
         'to equal', Buffer.from('string'));
     });
 
+    it('should convert typed array', function() {
+      expect(AtviseFile.encodeValue(
+        { value: new Uint16Array([1, 2]) }, DataType.UInt16, VariantArrayType.Array
+      ).toString(),
+      'to equal', JSON.stringify([1, 2], null, '  '));
+    });
+
     context('with an array passed', function() {
       it('should JSON encode standard values', function() {
         const value = ['test', 'another'];
@@ -250,6 +257,12 @@ describe('AtviseFile', function() {
       const buffer = new Buffer('test');
       expect(AtviseFile.decodeValue(buffer, DataType.ByteString, VariantArrayType.Scalar),
         'to equal', buffer);
+    });
+
+    it('should throw if an array variable\'s value is scalar', function() {
+      const value = 24;
+      return expect(() => AtviseFile.decodeValue(value, DataType.Int16, VariantArrayType.Array),
+        'to throw', /not an array/i);
     });
 
     context('with an array passed', function() {


### PR DESCRIPTION
Fixes an issue introduced in beta 28, where typed arrays where stringified as objects (e.g. { "0": 123, "1": 124 })