### PR TITLE
fix: Treat `.htm` files as HTML resources

### DIFF
--- a/src/lib/server/Types.js
+++ b/src/lib/server/Types.js
@@ -79,6 +79,7 @@ const AtviseTypes = [
   new AtviseType('TranslationTable', 'locs', DataType.XmlElement),
   new AtviseResourceType('Pdf', 'pdf'),
   new AtviseResourceType('Html', 'html'),
+  new AtviseResourceType('Html', 'htm'),
   new AtviseResourceType('Javascript', 'js'),
   new AtviseResourceType('Wave', 'wav'),
   new AtviseResourceType('Gif', 'gif'),


### PR DESCRIPTION
Fixes #188