### PR TITLE
fix(transform): Do not add trailing newlines by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Source code management utilities for atvise
 
-[![CircleCI](https://circleci.com/gh/atSCM/atscm.svg?style=shield)](https://circleci.com/gh/atSCM/atscm)
+[![CircleCI](https://circleci.com/gh/atSCM/atscm.svg?style=shield)](https://circleci.com/gh/atSCM/workflows/atscm)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/d9e5vi6a7ygisjsr/branch/master?svg=true&pendingText=windows%20tests%20pending&passingText=windows%20tests%20passing&failingText=windows%20tests%20failing)](https://ci.appveyor.com/project/LukasHechenberger/atscm)
 [![codecov](https://codecov.io/gh/atSCM/atscm/branch/master/graph/badge.svg)](https://codecov.io/gh/atSCM/atscm)
 [![ESDoc](https://atscm.github.io/atscm/badge.svg)](https://atscm.github.io/atscm)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Source code management utilities for atvise
 
 [![CircleCI](https://circleci.com/gh/atSCM/atscm.svg?style=shield)](https://circleci.com/gh/atSCM/atscm)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/d9e5vi6a7ygisjsr?svg=true&pendingText=windows%20tests%20pending&passingText=windows%20tests%20passing&failingText=windows%20tests%20failing)](https://ci.appveyor.com/project/LukasHechenberger/atscm)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/d9e5vi6a7ygisjsr/branch/master?svg=true&pendingText=windows%20tests%20pending&passingText=windows%20tests%20passing&failingText=windows%20tests%20failing)](https://ci.appveyor.com/project/LukasHechenberger/atscm)
 [![codecov](https://codecov.io/gh/atSCM/atscm/branch/master/graph/badge.svg)](https://codecov.io/gh/atSCM/atscm)
 [![ESDoc](https://atscm.github.io/atscm/badge.svg)](https://atscm.github.io/atscm)
 [![Greenkeeper badge](https://badges.greenkeeper.io/atSCM/atscm.svg)](https://greenkeeper.io/)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:integration": "npm run -s test:base -- \"test/integration/**/*.spec.js\"",
     "test:watch": "npm test -- --watch --reporter min",
     "test:coverage": "nyc --reporter=html npm run test:unit",
-    "test:docs": "blcl docs/api --exclude https://circleci.com/gh/atSCM/atscm"
+    "test:docs": "blcl docs/api --exclude https://circleci.com/gh/atSCM/workflows/atscm"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@ export { default as PartialTransformer } from './lib/transform/PartialTransforme
 export { default as SplittingTransformer } from './lib/transform/SplittingTransformer';
 export { default as DisplayTransformer } from './transform/DisplayTransformer';
 export { default as ScriptTransformer } from './transform/ScriptTransformer';
+export { default as NewlinesTransformer } from './transform/Newlines';

--- a/src/lib/config/Atviseproject.js
+++ b/src/lib/config/Atviseproject.js
@@ -42,7 +42,8 @@ export default class Atviseproject {
   }
 
   /**
-   * The transformers to use in this project. Defaults to a single {@link DisplayTransformer}.
+   * The transformers to use in this project. Returns {@link DisplayTransformer} and
+   * {@link ScriptTransformer} by default.
    * @type {Transformer[]}
    */
   static get useTransformers() {

--- a/src/lib/config/Atviseproject.js
+++ b/src/lib/config/Atviseproject.js
@@ -3,6 +3,7 @@
 import NodeId from '../model/opcua/NodeId';
 import DisplayTransformer from '../../transform/DisplayTransformer';
 import ScriptTransformer from '../../transform/ScriptTransformer';
+import NewlinesTransformer from '../../transform/Newlines';
 
 /**
  * An *atvise-scm* project's configuration.
@@ -42,14 +43,15 @@ export default class Atviseproject {
   }
 
   /**
-   * The transformers to use in this project. Returns {@link DisplayTransformer} and
-   * {@link ScriptTransformer} by default.
+   * The transformers to use in this project. Returns a {@link DisplayTransformer}, a
+   * {@link ScriptTransformer} and a {@link NewlinesTransformer} by default.
    * @type {Transformer[]}
    */
   static get useTransformers() {
     return [
       new DisplayTransformer(),
       new ScriptTransformer(),
+      new NewlinesTransformer({ trailingNewlines: false }),
     ];
   }
 

--- a/src/lib/gulp/PullStream.js
+++ b/src/lib/gulp/PullStream.js
@@ -31,8 +31,7 @@ export default class PullStream {
     return Transformer.applyTransformers(
       readStream
         .pipe(mappingStream),
-      ProjectConfig.useTransformers
-        .concat(new NewlinesTransformer()),
+      ProjectConfig.useTransformers,
       TransformDirection.FromDB
     )
       .pipe(dest('./src'))

--- a/src/lib/gulp/PullStream.js
+++ b/src/lib/gulp/PullStream.js
@@ -4,7 +4,6 @@ import Logger from 'gulplog';
 import ProjectConfig from '../../config/ProjectConfig';
 import Transformer, { TransformDirection } from '../transform/Transformer';
 import MappingTransformer from '../../transform/Mapping';
-import NewlinesTransformer from '../../transform/Newlines';
 
 /**
  * A stream that transforms read {@link ReadStream.ReadResult}s and stores the on the filesystem.

--- a/src/lib/gulp/PushStream.js
+++ b/src/lib/gulp/PushStream.js
@@ -37,8 +37,7 @@ export default class PushStream {
     return Transformer.applyTransformers(
       srcStream
         .pipe(mappingStream),
-      ProjectConfig.useTransformers
-        .concat(new NewlinesTransformer()),
+      ProjectConfig.useTransformers,
       TransformDirection.FromFilesystem
     )
       .pipe(writeStream)

--- a/src/lib/gulp/PushStream.js
+++ b/src/lib/gulp/PushStream.js
@@ -6,7 +6,6 @@ import MappingTransformer from '../../transform/Mapping';
 import WriteStream from '../server/WriteStream';
 import CreateNodeStream from '../server/CreateNodeStream';
 import AddReferencesStream from '../server/AddReferencesStream';
-import NewlinesTransformer from '../../transform/Newlines';
 
 /**
  * A stream that transforms read {@link vinyl~File}s and pushes them to atvise server.

--- a/src/transform/Newlines.js
+++ b/src/transform/Newlines.js
@@ -9,14 +9,31 @@ const trailingNewlineRegExp = /\r\n+$/;
 
 /**
  * A transformer that handles newline characters in files. During a pull, all breaks are converted
- * the OS-native EOL character and a trailing newline is added (for better git diffs). On push, CRLF
- * characters are used and those trailing newlines are removed again.
+ * the OS-native EOL character and (optionally) a trailing newline is added (for better git diffs).
+ * On push, CRLF characters are used and those trailing newlines are removed again.
  */
 export default class NewlinesTransformer extends PartialTransformer {
 
   /**
+   * Creates a new newline transformer.
+   * @param {Object} [options={}] The options to use.
+   * @param {boolean} [options.trailingNewlines] If trailing newlines should be added. Pass *true*
+   * for better git diffs.
+   */
+  constructor(options = {}) {
+    super(options);
+
+    /**
+     * If newlines should be added to pulled files.
+     * @type {boolean}
+     */
+    this._addTrailingNewlines = options.trailingNewlines || false;
+  }
+
+  /**
    * Returns `true` for all files except binary ones.
    * @param {AtviseFile} file The file being transformed.
+   * @return {boolean} Always `true`.
    */
   shouldBeTransformed(file) {
     return file.stem[0] === '.' || file.dataType !== DataType.ByteString;
@@ -31,7 +48,7 @@ export default class NewlinesTransformer extends PartialTransformer {
   transformFromDB(file, enc, callback) {
     let str = file.contents.toString().replace(/\r?\n/g, EOL);
 
-    if (!str.match(trailingNewlineRegExp)) {
+    if (this._addTrailingNewlines && !str.match(trailingNewlineRegExp)) {
       str += EOL;
     }
 
@@ -47,9 +64,12 @@ export default class NewlinesTransformer extends PartialTransformer {
    * @param {function(err: ?Error, data: ?AtviseFile)} callback Called with resulting file.
    */
   transformFromFilesystem(file, enc, callback) {
-    const str = file.contents.toString()
-      .replace(/\r?\n/g, '\r\n')
-      .replace(trailingNewlineRegExp, '');
+    let str = file.contents.toString()
+      .replace(/\r?\n/g, '\r\n');
+
+    if (this._addTrailingNewlines) {
+      str = str.replace(trailingNewlineRegExp, '');
+    }
 
     file.contents = Buffer.from(str); // eslint-disable-line no-param-reassign
 

--- a/src/transform/Newlines.js
+++ b/src/transform/Newlines.js
@@ -5,7 +5,7 @@ import PartialTransformer from '../lib/transform/PartialTransformer';
 /**
  * A regular expression matching trailing newlines.
  */
-const trailingNewlineRegExp = /\r\n+$/;
+const trailingNewlineRegExp = /\r?\n$/;
 
 /**
  * A transformer that handles newline characters in files. During a pull, all breaks are converted

--- a/test/src/transform/Newlines.spec.js
+++ b/test/src/transform/Newlines.spec.js
@@ -1,0 +1,100 @@
+import { EOL } from 'os';
+import expect from '../../expect';
+import NewlinesTransformer from '../../../src/transform/Newlines';
+import File from '../../../src/lib/server/AtviseFile';
+
+describe.only('NewlinesTransformer', function() {
+  /** @test {MappingTransformer#constructor} */
+  describe('#constructor', function() {
+    context('trailingNewlines option', function() {
+      it('should default to false', function() {
+        const transformer = new NewlinesTransformer();
+        expect(transformer._addTrailingNewlines, 'to be', false);
+
+        const transformer2 = new NewlinesTransformer({});
+        expect(transformer2._addTrailingNewlines, 'to be', false);
+      });
+    });
+  });
+
+  /** @test {NewlinesTransformer#shouldBeTransformed} */
+  describe('#shouldBeTransformed', function() {
+    it('should return true for reference files', function() {
+      expect(NewlinesTransformer.prototype.shouldBeTransformed, 'called with',
+        [new File({
+          path: './src/test/.Object.json',
+          contents: Buffer.from('{}'),
+        })], 'to be', true);
+    });
+
+    it('should return true for source files', function() {
+      expect(NewlinesTransformer.prototype.shouldBeTransformed, 'called with',
+        [new File({
+          path: './src/test/Test.script/Test.js',
+          contents: Buffer.from(''),
+        })], 'to be', true);
+    });
+
+    it('should return false for binary files', function() {
+      expect(NewlinesTransformer.prototype.shouldBeTransformed, 'called with',
+        [new File({
+          path: './src/test/Test.jpg',
+          contents: Buffer.from(''),
+        })], 'to be', false);
+    });
+  });
+
+  /** @test {NewlinesTransformer#transformFromDB} */
+  describe('#transformFromDB', function() {
+    it('should replace non-native newlines', function() {
+      const transformer = new NewlinesTransformer({ trailingNewlines: false });
+      const lines = ['first line', 'second'];
+
+      return expect(cb => transformer.transformFromDB(new File({
+        path: './src/test/Test.script/Test.js',
+        contents: Buffer.from(lines.join('\r\n')),
+      }), 'utf8', cb), 'to call the callback without error')
+        .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
+          'to equal', lines.join(EOL)));
+    });
+
+    it('should add trailing newlines if set', function() {
+      const transformer = new NewlinesTransformer({ trailingNewlines: true });
+      const lines = ['first line', 'second'];
+
+      return expect(cb => transformer.transformFromDB(new File({
+        path: './src/test/Test.script/Test.js',
+        contents: Buffer.from(lines.join('\r\n')),
+      }), 'utf8', cb), 'to call the callback without error')
+        .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
+          'to equal', lines.concat('').join(EOL)));
+    });
+  });
+
+  /** @test {NewlinesTransformer#transformFromFilesystem} */
+  describe('#transformFromFilesystem', function() {
+    it('should replace native newlines', function() {
+      const transformer = new NewlinesTransformer({ trailingNewlines: false });
+      const lines = ['first line', 'second'];
+
+      return expect(cb => transformer.transformFromFilesystem(new File({
+        path: './src/test/Test.script/Test.js',
+        contents: Buffer.from(lines.join(EOL)),
+      }), 'utf8', cb), 'to call the callback without error')
+        .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
+          'to equal', lines.join('\r\n')));
+    });
+
+    it('should remove trailing newlines if set', function() {
+      const transformer = new NewlinesTransformer({ trailingNewlines: true });
+      const lines = ['first line', 'second'];
+
+      return expect(cb => transformer.transformFromFilesystem(new File({
+        path: './src/test/Test.script/Test.js',
+        contents: Buffer.from(lines.concat('').join(EOL)),
+      }), 'utf8', cb), 'to call the callback without error')
+        .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
+          'to equal', lines.join('\r\n')));
+    });
+  });
+});

--- a/test/src/transform/Newlines.spec.js
+++ b/test/src/transform/Newlines.spec.js
@@ -96,5 +96,17 @@ describe.only('NewlinesTransformer', function() {
         .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
           'to equal', lines.join('\r\n')));
     });
+
+    it('should remove only one trailing newline if set', function() {
+      const transformer = new NewlinesTransformer({ trailingNewlines: true });
+      const lines = ['first line', 'second'];
+
+      return expect(cb => transformer.transformFromFilesystem(new File({
+        path: './src/test/Test.script/Test.js',
+        contents: Buffer.from(lines.concat('').concat('').join(EOL)),
+      }), 'utf8', cb), 'to call the callback without error')
+        .then(([file]) => expect(file.contents, 'when decoded as', 'utf8',
+          'to equal', lines.concat('').join('\r\n')));
+    });
   });
 });

--- a/test/src/transform/Newlines.spec.js
+++ b/test/src/transform/Newlines.spec.js
@@ -3,7 +3,7 @@ import expect from '../../expect';
 import NewlinesTransformer from '../../../src/transform/Newlines';
 import File from '../../../src/lib/server/AtviseFile';
 
-describe.only('NewlinesTransformer', function() {
+describe('NewlinesTransformer', function() {
   /** @test {MappingTransformer#constructor} */
   describe('#constructor', function() {
     context('trailingNewlines option', function() {


### PR DESCRIPTION
Trailing newlines can now be added by passing `{ trailingNewlines: true }` to the *NewlinesTransformer* class.