### PR TITLE
fix: Enforce tag order in display svgs

### DIFF
--- a/src/lib/transform/XMLTransformer.js
+++ b/src/lib/transform/XMLTransformer.js
@@ -1,5 +1,6 @@
 import { EOL } from 'os';
 import { xml2js, js2xml } from 'xml-js';
+import { isElement, removeChild } from '../helpers/xml';
 import { TransformDirection } from './Transformer';
 import SplittingTransformer from './SplittingTransformer';
 
@@ -22,6 +23,22 @@ export default class XMLTransformer extends SplittingTransformer {
             attributes: { version: '1.0', encoding: 'UTF-8', standalone: 'no' },
           },
         });
+      }
+
+      const root = object.elements.find(isElement);
+
+      function addOnTop(parent, name) {
+        const node = removeChild(parent, name);
+
+        if (node) {
+          parent.elements.unshift(node);
+        }
+      }
+
+      if (root.elements) {
+        addOnTop(root, 'metadata');
+        addOnTop(root, 'defs');
+        addOnTop(root, 'title');
       }
 
       return js2xml(object, Object.assign(buildOptions, {

--- a/test/src/lib/transform/XMLTransformer.spec.js
+++ b/test/src/lib/transform/XMLTransformer.spec.js
@@ -61,7 +61,7 @@ describe('XMLTransformer', function() {
   <title>Test</title>
 </svg>`, { compact: false });
       expect(transformer.builder(dom), 'to equal',
-        `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        nativeEOLs(`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg>
   <title>Test</title>
   <defs>
@@ -71,7 +71,7 @@ describe('XMLTransformer', function() {
     <some>meta</some>
   </metadata>
   <rect x="12" y="13"/>
-</svg>`);
+</svg>`));
     });
   });
 

--- a/test/src/lib/transform/XMLTransformer.spec.js
+++ b/test/src/lib/transform/XMLTransformer.spec.js
@@ -1,6 +1,6 @@
 import { EOL } from 'os';
 import expect from 'unexpected';
-import { xml2js } from 'xml-js';
+import { js2xml, xml2js } from 'xml-js';
 import Transformer, { TransformDirection } from '../../../../src/lib/transform/Transformer';
 import XMLTransformer from '../../../../src/lib/transform/XMLTransformer';
 
@@ -45,6 +45,33 @@ describe('XMLTransformer', function() {
 
       expect(transformer.builder, 'to be defined');
       expect(transformer.builder, 'to be', transformer._fromFilesystemBuilder);
+    });
+
+    it('should enforce tag order', function() {
+      const transformer = new XMLTransformer({ direction: TransformDirection.FromDB });
+      const dom = xml2js(`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg>
+  <rect x="12" y="13"/>
+  <defs>
+    <some>defs</some>
+  </defs>
+  <metadata>
+    <some>meta</some>
+  </metadata>
+  <title>Test</title>
+</svg>`, { compact: false });
+      expect(transformer.builder(dom), 'to equal',
+        `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg>
+  <title>Test</title>
+  <defs>
+    <some>defs</some>
+  </defs>
+  <metadata>
+    <some>meta</some>
+  </metadata>
+  <rect x="12" y="13"/>
+</svg>`);
     });
   });
 

--- a/test/src/lib/transform/XMLTransformer.spec.js
+++ b/test/src/lib/transform/XMLTransformer.spec.js
@@ -1,6 +1,6 @@
 import { EOL } from 'os';
 import expect from 'unexpected';
-import { js2xml, xml2js } from 'xml-js';
+import { xml2js } from 'xml-js';
 import Transformer, { TransformDirection } from '../../../../src/lib/transform/Transformer';
 import XMLTransformer from '../../../../src/lib/transform/XMLTransformer';
 


### PR DESCRIPTION
Prevents diffs if *atvise builder* reorders title, defs or metadata sections