### PR TITLE
fix(push): Use correct root objects folder id

### DIFF
--- a/src/lib/server/CreateNodeStream.js
+++ b/src/lib/server/CreateNodeStream.js
@@ -30,7 +30,7 @@ export default class CreateNodeStream extends CallScriptStream {
   scriptParameters(file) {
     const options = {
       nodeId: file.nodeId,
-      parentNodeId: file.parent ? file.parent.nodeId : 'Objects',
+      parentNodeId: file.parent ? file.parent.nodeId : 85,
       nodeClass: file.nodeClass.value,
       typeDefinition: file.typeDefinition,
       browseName: file.idName,


### PR DESCRIPTION
Fixes an issue that caused a script error when creating root nodes on atserver < 3