### PR TITLE
fix(pull): Ignore invalid alarm configuration limit nodes

### DIFF
--- a/src/lib/config/Atviseproject.js
+++ b/src/lib/config/Atviseproject.js
@@ -7,6 +7,7 @@ import {
   QuickDynamicTransformer,
 } from '../../transform/ScriptTransformer.js';
 import MappingTransformer from '../../transform/Mapping';
+import AlarmConfigTransformer from '../../transform/AlarmConfigTransformer';
 
 /**
  * An *atvise-scm* project's configuration.
@@ -52,6 +53,7 @@ export default class Atviseproject {
    */
   static get useTransformers() {
     return [
+      new AlarmConfigTransformer(),
       new DisplayTransformer(),
       new ServerscriptTransformer(),
       new QuickDynamicTransformer(),

--- a/src/lib/server/NodeBrowser.js
+++ b/src/lib/server/NodeBrowser.js
@@ -188,7 +188,7 @@ export default class NodeBrowser {
             const arrayType = valueRank < 0 ? VariantArrayType.Scalar : VariantArrayType.Array;
 
             return resolve({
-              dataType,
+              dataType: DataType[dataType.value],
               arrayType,
               value: null,
             });

--- a/src/lib/server/NodeBrowser.js
+++ b/src/lib/server/NodeBrowser.js
@@ -1,7 +1,7 @@
 import { ObjectIds } from 'node-opcua/lib/opcua_node_ids.js';
 import { BrowseDirection } from 'node-opcua/lib/services/browse_service.js';
 import { AttributeIds } from 'node-opcua/lib/services/read_service';
-import { VariantArrayType } from 'node-opcua/lib/datamodel/variant';
+import { VariantArrayType, DataType } from 'node-opcua/lib/datamodel/variant';
 import Logger from 'gulplog';
 import PromiseQueue from 'p-queue';
 import ProjectConfig from '../../config/ProjectConfig';

--- a/src/tasks/pull.js
+++ b/src/tasks/pull.js
@@ -22,10 +22,14 @@ export function performPull(nodes, options = {}) {
   const browser = new NodeBrowser({
     ...options,
     async handleNode(node, { transform = true } = {}) {
+      let removed = false;
       const context = {
         _added: [],
         addNode(n) {
           this._added.push(n);
+        },
+        remove: () => {
+          removed = true;
         },
       };
 
@@ -33,6 +37,7 @@ export function performPull(nodes, options = {}) {
         await applyTransforms(node, context);
       }
 
+      if (removed) { return; }
       await writeStream.writeAsync(node);
 
       // Enqueue added nodes

--- a/src/transform/AlarmConfigTransformer.ts
+++ b/src/transform/AlarmConfigTransformer.ts
@@ -1,0 +1,57 @@
+import { DataType } from 'node-opcua/lib/datamodel/variant';
+import { ItemOf } from 'node-opcua/lib/misc/enum.js';
+import PartialTransformer from '../lib/transform/PartialTransformer';
+import Node from '../lib/model/Node';
+
+const limitNodeNameRegExp = /\.(upper|lower)_limit(_deadband)?$/;
+
+/**
+ * Returns an alarm limit's trigger / source node's data type.
+ * Assuming a regular project structure this is the third parent node:
+ * **Source** > AlarmConfiguration > AlarmCondition > FilterNode.
+ * @param node The limit node to check.
+ */
+function getLimitTriggerType(node: Node): (ItemOf<typeof DataType> | undefined) {
+  return node && node.parent && node.parent.parent &&
+    node.parent.parent.parent && node.parent.parent.parent.dataType;
+}
+
+/**
+ * A transformer ensuring no invalid alarm condition filter nodes are pulled.
+ */
+export default class LintTransformer extends PartialTransformer {
+
+  /**
+   * Returns `true` for all alarm condition filter nodes.
+   * @param node The node to check.
+   */
+  public shouldBeTransformed(node: Node): boolean {
+    return Boolean(
+      node.parent &&
+      node.parent.hasTypeDefinition('ObjectTypes.ATVISE.AlarmConditionControl.Limit') &&
+      node.nodeId.match(limitNodeNameRegExp)
+    );
+  }
+
+  /**
+   * Removes filter alarm condition filter nodes that have an invalid dataType.
+   * @param node The node to transform.
+   * @param context The transform context.
+   */
+  public async transformFromDB(node: Node, { remove }: { remove: () => void }): Promise<void> {
+    if (!this.shouldBeTransformed(node)) return;
+
+    const triggerDataType = getLimitTriggerType(node);
+
+    // NOTE: When no trigger node was found, the node is ignored as well
+    // This means that during incomplete pulls (e.g. in response to a watch event) these nodes are
+    // not updated.
+    if (node.dataType !== triggerDataType) {
+      remove();
+    }
+  }
+
+  /** Does nothing. */
+  public async transformFromFilesystem(): Promise<void> { return; }
+
+}


### PR DESCRIPTION
Fixes an issue where the server abruptly closed the connection when trying to push a raw variant node as e.g. upper_limit of an alarm condition