### PR TITLE
feat(api): Add convenient api entry file

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,1 @@
+module.exports = require('./out/api.js');


### PR DESCRIPTION
From now on, we can `require('atscm/api')` instead of `require('atscm/out/api')`.