### PR TITLE
feat(atscm): Sort XML attributes to minimize diffs

### DIFF
--- a/packages/atscm/src/lib/config/Atviseproject.ts
+++ b/packages/atscm/src/lib/config/Atviseproject.ts
@@ -55,6 +55,13 @@ export default class Atviseproject {
     return false;
   }
 
+  private static get xmlTransformerOptions() {
+    return {
+      sortXMLAttributes: this.sortXMLAttributes,
+      removeBuilderRefs: this.removeBuilderRefs,
+    };
+  }
+
   /**
    * The transformers to use in this project. Returns a {@link DisplayTransformer}, a
    * {@link ScriptTransformer} and a {@link NewlinesTransformer} by default.
@@ -62,9 +69,9 @@ export default class Atviseproject {
   static get useTransformers(): Transformer[] {
     return [
       new AlarmConfigTransformer(),
-      new DisplayTransformer(),
-      new ServerscriptTransformer(),
-      new QuickDynamicTransformer(),
+      new DisplayTransformer(this.xmlTransformerOptions),
+      new ServerscriptTransformer(this.xmlTransformerOptions),
+      new QuickDynamicTransformer(this.xmlTransformerOptions),
       new MappingTransformer() as any,
     ];
   }

--- a/packages/atscm/src/lib/config/Atviseproject.ts
+++ b/packages/atscm/src/lib/config/Atviseproject.ts
@@ -171,4 +171,20 @@ export default class Atviseproject {
   static get timeout(): number {
     return 10000;
   }
+
+  /**
+   * Remove `atv:refpx` and `atv:refpy` attributes from XML to minimize diffs between pulls. This
+   * will eventually default to *true* in a future atscm version.
+   */
+  static get removeBuilderRefs(): boolean {
+    return false;
+  }
+
+  /**
+   * Sort XML attributes to minimize diffs between pulls. This will eventually default to *true* in
+   * a future atscm version.
+   */
+  static get sortXMLAttributes(): boolean {
+    return false;
+  }
 }

--- a/packages/atscm/src/lib/transform/XMLTransformer.js
+++ b/packages/atscm/src/lib/transform/XMLTransformer.js
@@ -1,6 +1,5 @@
 import { EOL } from 'os';
 import { parse, render, isElement, moveToTop, attributeValues } from 'modify-xml';
-import ProjectConfig from '../../config/ProjectConfig';
 import { TransformDirection } from './Transformer';
 import SplittingTransformer from './SplittingTransformer';
 
@@ -22,8 +21,14 @@ export default class XMLTransformer extends SplittingTransformer {
    * Creates a new XMLTransformer based on some options.
    * @param {Object} [options] The options to use.
    */
-  constructor(options = {}) {
+  constructor({ sortXMLAttributes = false, removeBuilderRefs = false, ...options } = {}) {
     super(options);
+
+    /** @protected */
+    this.sortXMLAttributes = sortXMLAttributes;
+
+    /** @protected */
+    this.removeBuilderRefs = removeBuilderRefs;
 
     function build(object, buildOptions) {
       const root = object.childNodes.find((n) => isElement(n));
@@ -35,13 +40,13 @@ export default class XMLTransformer extends SplittingTransformer {
         moveToTop(root, 'title');
       }
 
-      if (ProjectConfig.sortXMLAttributes || ProjectConfig.removeBuilderRefs)
+      if (sortXMLAttributes || removeBuilderRefs)
         walk(root, (e) => {
           /* eslint-disable no-param-reassign */
-          if (ProjectConfig.removeBuilderRefs)
+          if (removeBuilderRefs)
             e.attributes = e.attributes.filter((a) => !['atv:refpx', 'atv:refpy'].includes(a.name));
 
-          if (ProjectConfig.sortXMLAttributes)
+          if (sortXMLAttributes)
             e.attributes = e.attributes.sort((a, b) => (b.name > a.name ? -1 : 1));
 
           delete e.openTag;
@@ -77,7 +82,7 @@ export default class XMLTransformer extends SplittingTransformer {
    * @param {import('modify-xml').Element} node The node to handle.
    */
   sortedAttributeValues(node) {
-    if (!ProjectConfig.sortXMLAttributes) return attributeValues(node);
+    if (!this.sortXMLAttributes) return attributeValues(node);
 
     return Object.fromEntries(
       Object.entries(attributeValues(node)).sort((a, b) => (b > a ? -1 : 1))

--- a/packages/atscm/src/transform/DisplayTransformer.ts
+++ b/packages/atscm/src/transform/DisplayTransformer.ts
@@ -144,7 +144,7 @@ export default class DisplayTransformer extends XMLTransformer {
         config.parameters = [];
 
         paramTags.forEach((n) =>
-          config.parameters.push(attributeValues(n) as DisplayConfig['parameters'][0])
+          config.parameters.push(this.sortedAttributeValues(n) as DisplayConfig['parameters'][0])
         );
       }
     }

--- a/packages/atscm/src/transform/ScriptTransformer.ts
+++ b/packages/atscm/src/transform/ScriptTransformer.ts
@@ -116,7 +116,7 @@ export class AtviseScriptTransformer extends XMLTransformer {
 
     return paramTags.map((node) => {
       const { childNodes } = node;
-      const attributes = attributeValues(node);
+      const attributes = this.sortedAttributeValues(node);
       const param = Object.assign({}, attributes) as ServerscriptConfig['parameters'][0];
 
       // Handle relative parameter targets


### PR DESCRIPTION
A big step ahead #436 

**Enable by setting *removeBeuilderRefs* and *sortXMLAttributes* in your Atviseproject file**

```diff
  class AtscmBeta extends Atviseproject {
    ...
    static get port() {
      return {
        opc: 4840,
        http: 80,
      };
    }
+
+   static get removeBuilderRefs() {
+     return true;
+   }
+
+   static get sortXMLAttributes() {
+     return true;
+   }
  }
```